### PR TITLE
:white_check_mark: Fix CI workflow on public repository

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -17,7 +17,7 @@ jobs:
     name: Run unit tests
     steps:
       - uses: actions/checkout@v3
-      - name: 'Create .env file'
+      - name: "Create .env file"
         run: |
           touch .env
           echo ENVIRONMENT=${{ env.ENVIRONMENT }} >> .env
@@ -31,3 +31,6 @@ jobs:
         run: yarn
       - name: Run test scripts
         run: yarn test
+        # Github token to run public workflows
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
The github secret token is used to run a Github Actions workflow file on a public repository. It is important here that we have branch protection rules that do not allow improper use of the actions, for e.g:
- printing out repository/organization secrets
- infinite workflow runs, etc.

It is advised to have branch protection rules such as requiring an approval before running workflows from new users, and approvals to merge such PRs.